### PR TITLE
Deprecate add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@
 A simple utility to generate signed certificate files to allow local control of
 a Lutron Caseta smart bridge.
 
+## Deprecation warning
+
+**This add-on is in a deprecated state!**
+
+This add-on used to be helpful when in need of getting the signed certificates
+of your Lutron Caseta smart bridge in order to use it with Home Assistant.
+
+Nowadays, Home Assistant does support/help with this itself and this add-on
+is therefore no longer needed.
+
+If you want to integrate Lutron Caseta with Home Assistant, than follow
+the instructions on the Home Assistant Lutron Caseta integration documentation
+page:
+
+<https://www.home-assistant.io/integrations/lutron_caseta/#configuration>
+
 ## About
 
 This add-on will guide you through the necessary steps to create signed
@@ -116,7 +132,7 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/addon-lutron-cert/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-lutron-cert.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2021.svg
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
+[project-stage-shield]: https://img.shields.io/badge/project%20stage-%20!%20DEPRECATED%20%20%20!-ff0000.svg
 [reddit]: https://reddit.com/r/homeassistant
 [releases-shield]: https://img.shields.io/github/release/hassio-addons/addon-lutron-cert.svg
 [releases]: https://github.com/hassio-addons/addon-lutron-cert/releases

--- a/lutron-cert/.README.j2
+++ b/lutron-cert/.README.j2
@@ -9,6 +9,22 @@
 A simple utility to generate signed certificate files to allow local control of
 a Lutron Caseta smart bridge.
 
+## Deprecation warning
+
+**This add-on is in a deprecated state!**
+
+This add-on used to be helpful when in need of getting the signed certificates
+of your Lutron Caseta smart bridge in order to use it with Home Assistant.
+
+Nowadays, Home Assistant does support/help with this itself and this add-on
+is therefore no longer needed.
+
+If you want to integrate Lutron Caseta with Home Assistant, than follow
+the instructions on the Home Assistant Lutron Caseta integration documentation
+page:
+
+<https://www.home-assistant.io/integrations/lutron_caseta/#configuration>
+
 ## About
 
 This add-on will guide you through the necessary steps to create signed
@@ -86,6 +102,6 @@ If you are more interested in stable releases of our add-ons:
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-lutron-certificate/70317?u=frenck
 [lutron-caseta-docs]: https://www.home-assistant.io/components/lutron_caseta/
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2021.svg
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
+[project-stage-shield]: https://img.shields.io/badge/project%20stage-%20!%20DEPRECATED%20%20%20!-ff0000.svg
 [release-shield]: https://img.shields.io/badge/version-{{ version }}-blue.svg
 [release]: {{ repo }}/tree/{{ version }}

--- a/lutron-cert/DOCS.md
+++ b/lutron-cert/DOCS.md
@@ -4,6 +4,24 @@ This add-on will guide you through the necessary steps to create signed
 certificate files necessary to control your Lutron Caseta smart bridge with
 Home Assistant.
 
+## Deprecation warning
+
+**This add-on is in a deprecated state!**
+
+This add-on used to be helpful when in need of getting the signed certificates
+of your Lutron Caseta smart bridge in order to use it with Home Assistant.
+
+Nowadays, Home Assistant does support/help with this itself and this add-on
+is therefore no longer needed.
+
+If you want to integrate Lutron Caseta with Home Assistant, than follow
+the instructions on the Home Assistant Lutron Caseta integration documentation
+page:
+
+<https://www.home-assistant.io/integrations/lutron_caseta/#configuration>
+
+## Usage
+
 Three files will be created during successful execution of the wizard:
 
 - `/ssl/lutron/caseta.key`: the private key file used to generate the

--- a/lutron-cert/config.json
+++ b/lutron-cert/config.json
@@ -1,5 +1,6 @@
 {
   "name": "Lutron Certificate",
+  "stage": "deprecated",
   "version": "dev",
   "slug": "lutron-cert",
   "description": "Generate certificate to control Lutron Caseta bridge locally",


### PR DESCRIPTION
# Proposed Changes

This add-on used to be helpful when in need of getting the signed certificates
of your Lutron Caseta smart bridge in order to use it with Home Assistant.

Nowadays, Home Assistant does support/help with this itself and this add-on
is therefore no longer needed.

If you want to integrate Lutron Caseta with Home Assistant, than follow
the instructions on the Home Assistant Lutron Caseta integration documentation
page:

<https://www.home-assistant.io/integrations/lutron_caseta/#configuration>
